### PR TITLE
feat/tooltip

### DIFF
--- a/components/common/table/Table.stories.tsx
+++ b/components/common/table/Table.stories.tsx
@@ -17,7 +17,7 @@ const columns = [
   },
   {
     dataIndex: 'text',
-    title: <TableTitle title="content" />,
+    title: <TableTitle title="content" tooltip="This is the tooltip for text" />,
     render: (val: string) => <TableText>{val}</TableText>,
   },
 ];

--- a/components/common/table/Table.stories.tsx
+++ b/components/common/table/Table.stories.tsx
@@ -32,3 +32,9 @@ const Template: ComponentStory<any> = (args) => <Table tableProps={{ columns, ro
 export const Default = Template.bind({});
 
 Default.args = {};
+Default.parameters = {
+  design: {
+    type: 'figma',
+    url: 'https://www.figma.com/file/sCAngiTf2mPOWPo9kcoEE7/SubQuery-Design-System?node-id=578%3A7045',
+  },
+};

--- a/components/common/table/TableTitle.tsx
+++ b/components/common/table/TableTitle.tsx
@@ -7,21 +7,15 @@ interface TableTitleProps {
   title?: string;
   className?: string;
   tooltip?: string;
-  noTooltipIcon?: boolean;
+  // tooltipIcon?: boolean;
   children?: string | React.ReactNode;
 }
 
-export const TableTitle: React.FC<TableTitleProps> = ({
-  title,
-  children: childrenArg,
-  tooltip,
-  noTooltipIcon,
-  ...props
-}) => {
+export const TableTitle: React.FC<TableTitleProps> = ({ title, children: childrenArg, tooltip, ...props }) => {
   const children = childrenArg && typeof childrenArg === 'string' ? childrenArg.toUpperCase() : childrenArg;
   const content = title && title.toUpperCase();
   return (
-    <Typography type="secondary" variant="small" weight={600}>
+    <Typography type="secondary" variant="small" weight={600} tooltip={tooltip}>
       {content || children}
     </Typography>
   );

--- a/components/common/table/TableTitle.tsx
+++ b/components/common/table/TableTitle.tsx
@@ -3,7 +3,6 @@
 
 import * as React from 'react';
 import { Typography } from '../typography';
-
 interface TableTitleProps {
   title?: string;
   className?: string;
@@ -22,7 +21,7 @@ export const TableTitle: React.FC<TableTitleProps> = ({
   const children = childrenArg && typeof childrenArg === 'string' ? childrenArg.toUpperCase() : childrenArg;
   const content = title && title.toUpperCase();
   return (
-    <Typography type="secondary" variant="small">
+    <Typography type="secondary" variant="small" weight={600}>
       {content || children}
     </Typography>
   );

--- a/components/common/typography/Typography.module.css
+++ b/components/common/typography/Typography.module.css
@@ -89,3 +89,39 @@
 .secondary {
   color: var(--sq-gray600);
 }
+
+.w100 {
+  font-weight: 100;
+}
+
+.w200 {
+  font-weight: 200;
+}
+
+.w300 {
+  font-weight: 300;
+}
+
+.w400 {
+  font-weight: 400;
+}
+
+.w500 {
+  font-weight: 500;
+}
+
+.w600 {
+  font-weight: 600;
+}
+
+.w700 {
+  font-weight: 700;
+}
+
+.w800 {
+  font-weight: 800;
+}
+
+.w900 {
+  font-weight: 900;
+}

--- a/components/common/typography/Typography.module.css
+++ b/components/common/typography/Typography.module.css
@@ -125,3 +125,11 @@
 .w900 {
   font-weight: 900;
 }
+
+.tooltip {
+  cursor: pointer;
+}
+
+.tooltip:hover {
+  color: var(--sq-gray500);
+}

--- a/components/common/typography/Typography.stories.tsx
+++ b/components/common/typography/Typography.stories.tsx
@@ -65,4 +65,5 @@ export const Types = TypeTemplate.bind({});
 Types.args = {
   variant: 'default',
   type: 'default',
+  weight: 500,
 };

--- a/components/common/typography/Typography.stories.tsx
+++ b/components/common/typography/Typography.stories.tsx
@@ -41,6 +41,13 @@ Default.args = {
   variant: 'default',
 };
 
+Default.parameters = {
+  design: {
+    type: 'figma',
+    url: 'https://www.figma.com/file/sCAngiTf2mPOWPo9kcoEE7/SubQuery-Design-System?node-id=43%3A4',
+  },
+};
+
 const types: Array<ComponentProps<typeof Typography>['type']> = [
   'default',
   'secondary',
@@ -66,4 +73,10 @@ Types.args = {
   variant: 'default',
   type: 'default',
   weight: 500,
+};
+Types.parameters = {
+  design: {
+    type: 'figma',
+    url: 'https://www.figma.com/file/sCAngiTf2mPOWPo9kcoEE7/SubQuery-Design-System?node-id=3%3A170',
+  },
 };

--- a/components/common/typography/Typography.tsx
+++ b/components/common/typography/Typography.tsx
@@ -8,6 +8,7 @@ import styles from './Typography.module.css';
 type Props = {
   variant?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'large' | 'text' | 'medium' | 'small' | 'overline';
   type?: 'default' | 'secondary' | 'success' | 'warning' | 'danger';
+  weight?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
   className?: string;
 } & React.HTMLProps<HTMLParagraphElement>;
 
@@ -15,11 +16,12 @@ export const Typography: React.FC<Props> = ({
   children,
   variant = 'text',
   type = 'default',
+  weight = 500,
   className,
   ...htmlProps
 }) => {
   return (
-    <p {...htmlProps} className={clsx(styles.t, styles[variant], styles[type], className)}>
+    <p {...htmlProps} className={clsx(styles.t, styles[variant], styles[type], styles[`w${weight}`], className)}>
       {children}
     </p>
   );

--- a/components/common/typography/Typography.tsx
+++ b/components/common/typography/Typography.tsx
@@ -4,11 +4,13 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import styles from './Typography.module.css';
+import { Tooltip } from 'antd';
 
 type Props = {
   variant?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'large' | 'text' | 'medium' | 'small' | 'overline';
   type?: 'default' | 'secondary' | 'success' | 'warning' | 'danger';
   weight?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
+  tooltip?: string;
   className?: string;
 } & React.HTMLProps<HTMLParagraphElement>;
 
@@ -17,12 +19,25 @@ export const Typography: React.FC<Props> = ({
   variant = 'text',
   type = 'default',
   weight = 500,
+  tooltip,
   className,
   ...htmlProps
 }) => {
   return (
-    <p {...htmlProps} className={clsx(styles.t, styles[variant], styles[type], styles[`w${weight}`], className)}>
-      {children}
-    </p>
+    <Tooltip title={tooltip} placement="topLeft">
+      <p
+        {...htmlProps}
+        className={clsx(
+          styles.t,
+          styles[variant],
+          styles[type],
+          styles[`w${weight}`],
+          tooltip && styles.tooltip,
+          className,
+        )}
+      >
+        {children}
+      </p>
+    </Tooltip>
   );
 };

--- a/components/index.ts
+++ b/components/index.ts
@@ -9,3 +9,5 @@ import './styles.css';
 
 export * from './app';
 export * from './common';
+
+export { Tooltip } from 'antd';


### PR DESCRIPTION
Description: 

- Add `tooltip` params to Table, Typography component 
- Add hover effect to Typography component with tooltip
- Link Figma design addon to component
- Expose `Tooltip` from antd

Outcome: 
<img width="1513" alt="Screen Shot 2022-10-12 at 5 37 23 PM" src="https://user-images.githubusercontent.com/14360297/195251326-191bfd54-e5c9-409c-a033-3e6af7c3b649.png">
